### PR TITLE
Fix tests and provider

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
+  "presets": [
+    "@babel/preset-env",
+    ["@babel/preset-react", { "runtime": "automatic" }]
+  ]
 }

--- a/src/context/RestaurantFilterContext.jsx
+++ b/src/context/RestaurantFilterContext.jsx
@@ -5,8 +5,8 @@ const RestaurantFilterContext = createContext();
 
 export const useRestaurantFilter = () => useContext(RestaurantFilterContext);
 
-export const RestaurantFilterProvider = ({ children }) => {
-  const [showClosedRestaurants, setShowClosedRestaurants] = useState(false);
+export const RestaurantFilterProvider = ({ children, initialShowClosedRestaurants = false }) => {
+  const [showClosedRestaurants, setShowClosedRestaurants] = useState(initialShowClosedRestaurants);
 
   const toggleShowClosedRestaurants = () => {
     setShowClosedRestaurants(prevState => !prevState);
@@ -22,4 +22,5 @@ export const RestaurantFilterProvider = ({ children }) => {
 // Add prop types validation
 RestaurantFilterProvider.propTypes = {
   children: PropTypes.node.isRequired,
+  initialShowClosedRestaurants: PropTypes.bool,
 };


### PR DESCRIPTION
## Summary
- enable automatic JSX runtime to avoid missing React imports
- allow `RestaurantFilterProvider` to initialize closed-restaurants state via prop

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68455beb75ec83209aed244ff62259e6